### PR TITLE
freebsd/clang compile and portability changes

### DIFF
--- a/src/leansdr/dsp.h
+++ b/src/leansdr/dsp.h
@@ -4,6 +4,7 @@
 #include <math.h>
 #include "leansdr/framework.h"
 #include "leansdr/math.h"
+#include "leansdr/os_math_compat.h"
 
 namespace leansdr {
 

--- a/src/leansdr/generic.h
+++ b/src/leansdr/generic.h
@@ -138,7 +138,7 @@ struct file_carrayprinter : runnable {
       complex<T> *pin=in.rd(), *pend=pin+n;
       for ( ; pin<pend; ++pin )
 	fprintf(fout, format, pin->re*scale, pin->im*scale);
-      fprintf(fout, tail);
+      fprintf(fout, "%s", tail);
       fflush(fout);
     }
     in.read(n);

--- a/src/leansdr/math.h
+++ b/src/leansdr/math.h
@@ -2,6 +2,7 @@
 #define LEANSDR_MATH_H
 
 #include <math.h>
+#include "leansdr/os_math_compat.h"
 
 namespace leansdr {
 

--- a/src/leansdr/os_math_compat.h
+++ b/src/leansdr/os_math_compat.h
@@ -1,0 +1,35 @@
+#ifndef	__OS_MATH_COMPAT_H__
+#define	__OS_MATH_COMPAT_H__
+
+#include <math.h>
+
+/*
+ * FreeBSD doesn't have these functions defined.
+ */
+
+#if defined(__FreeBSD__)
+static inline void
+sincos(double x, double *s, double *c)
+{
+	*s = sin(x);
+	*c = cos(x);
+}
+
+static inline void
+sincosf(float x, float *s, float *c)
+{
+
+	*s = sinf(x);
+	*c = cosf(x);
+}
+
+static inline void
+sincosl(long double x, long double *s, long double *c)
+{
+
+	*s = sinl(x);
+	*c = cosl(x);
+}
+#endif	/* __FreeBSD__ */
+
+#endif	/* __OS_MATH_COMPAT_H__ */

--- a/src/leansdr/sdr.h
+++ b/src/leansdr/sdr.h
@@ -3,6 +3,7 @@
 
 #include "leansdr/math.h"
 #include "leansdr/dsp.h"
+#include "leansdr/os_math_compat.h"
 
 namespace leansdr {
 


### PR DESCRIPTION
This allows leansdr to compile/run on freebsd-head on clang 4.0.
Thanks for this!