### PR TITLE
Add support for complex int16_t and uint16_t type files

### DIFF
--- a/src/apps/leandvb.cc
+++ b/src/apps/leandvb.cc
@@ -27,7 +27,7 @@ using namespace leansdr;
 struct config {
   bool verbose, debug;
   bool highspeed;    // Demodulate raw u8 I/Q without preprocessing
-  enum { INPUT_U8, INPUT_U16, INPUT_F32 } input_format;
+  enum { INPUT_U8, INPUT_U16, INPUT_I16, INPUT_F32 } input_format;
   float float_scale; // Scaling factor for float data.
   bool loop_input;
   int input_buffer;  // Extra input buffer size
@@ -184,6 +184,16 @@ int run(config &cfg) {
     cconverter<u16, 2048, f32, 0, 1, 1> *r_convert =
       new cconverter<u16, 2048, f32,0, 1, 1>(&sch, *p_stdin, p_rawiq);
   }
+  if ( cfg.input_format == config::INPUT_I16 ) {
+    pipebuf<cs16> *p_stdin =
+      new pipebuf<cs16>(&sch, "stdin", BUF_BASEBAND+cfg.input_buffer);
+    file_reader<cs16> *r_stdin =
+      new file_reader<cs16>(&sch, 0, *p_stdin);
+    r_stdin->loop = cfg.loop_input;
+    cconverter<s16, 0, f32, 0, 1, 1> *r_convert =
+      new cconverter<s16, 0, f32,0, 1, 1>(&sch, *p_stdin, p_rawiq);
+  }
+
   if ( cfg.input_format == config::INPUT_F32 ) {
     pipebuf<cf32> *p_stdin =
       new pipebuf<cf32>(&sch, "stdin", BUF_BASEBAND+cfg.input_buffer);
@@ -865,7 +875,8 @@ void usage(const char *name, FILE *f, int c) {
   fprintf(f,
 	  "\nInput options:\n"
 	  "  --u8           Input format is 8-bit unsigned (rtl_sdr, default)\n"
-	  "  --u16          Input format is 16-bit unsigned (limeSDR)\n"
+	  "  --u16          Input format is 16-bit unsigned\n"
+          "  --i16          Input format is 16-bi signed (LimeSDR)\n"
 	  "  --f32          Input format is 32-bit float (gqrx)\n"
 	  "  -f HZ          Input sample rate (default: 2.4e6)\n"
 	  "  --loop         Repeat (stdin must be a file)\n"
@@ -1042,6 +1053,8 @@ int main(int argc, const char *argv[]) {
       cfg.input_format = config::INPUT_F32;
     else if ( ! strcmp(argv[i], "--u16") )
       cfg.input_format = config::INPUT_U16;
+    else if ( ! strcmp(argv[i], "--i16") )
+      cfg.input_format = config::INPUT_I16;
     else if ( ! strcmp(argv[i], "--u8") )
       cfg.input_format = config::INPUT_U8;
     else if ( ! strcmp(argv[i], "--float-scale") && i+1<argc )

--- a/src/apps/leandvb.cc
+++ b/src/apps/leandvb.cc
@@ -27,7 +27,7 @@ using namespace leansdr;
 struct config {
   bool verbose, debug;
   bool highspeed;    // Demodulate raw u8 I/Q without preprocessing
-  enum { INPUT_U8, INPUT_F32 } input_format;
+  enum { INPUT_U8, INPUT_U16, INPUT_F32 } input_format;
   float float_scale; // Scaling factor for float data.
   bool loop_input;
   int input_buffer;  // Extra input buffer size
@@ -174,6 +174,15 @@ int run(config &cfg) {
     r_stdin->loop = cfg.loop_input;
     cconverter<u8,128, f32,0, 1,1> *r_convert =
       new cconverter<u8,128, f32,0, 1,1>(&sch, *p_stdin, p_rawiq);
+  }
+  if ( cfg.input_format == config::INPUT_U16 ) {
+    pipebuf<cu16> *p_stdin =
+      new pipebuf<cu16>(&sch, "stdin", BUF_BASEBAND+cfg.input_buffer);
+    file_reader<cu16> *r_stdin =
+      new file_reader<cu16>(&sch, 0, *p_stdin);
+    r_stdin->loop = cfg.loop_input;
+    cconverter<u16, 2048, f32, 0, 1, 1> *r_convert =
+      new cconverter<u16, 2048, f32,0, 1, 1>(&sch, *p_stdin, p_rawiq);
   }
   if ( cfg.input_format == config::INPUT_F32 ) {
     pipebuf<cf32> *p_stdin =
@@ -856,6 +865,7 @@ void usage(const char *name, FILE *f, int c) {
   fprintf(f,
 	  "\nInput options:\n"
 	  "  --u8           Input format is 8-bit unsigned (rtl_sdr, default)\n"
+	  "  --u16          Input format is 16-bit unsigned (limeSDR)\n"
 	  "  --f32          Input format is 32-bit float (gqrx)\n"
 	  "  -f HZ          Input sample rate (default: 2.4e6)\n"
 	  "  --loop         Repeat (stdin must be a file)\n"
@@ -1030,6 +1040,8 @@ int main(int argc, const char *argv[]) {
 #endif
     else if ( ! strcmp(argv[i], "--f32") )
       cfg.input_format = config::INPUT_F32;
+    else if ( ! strcmp(argv[i], "--u16") )
+      cfg.input_format = config::INPUT_U16;
     else if ( ! strcmp(argv[i], "--u8") )
       cfg.input_format = config::INPUT_U8;
     else if ( ! strcmp(argv[i], "--float-scale") && i+1<argc )

--- a/src/leansdr/sdr.h
+++ b/src/leansdr/sdr.h
@@ -12,6 +12,7 @@ namespace leansdr {
 
   typedef complex<f32> cf32;
   typedef complex<u8> cu8;
+  typedef complex<u16> cu16;
   typedef complex<s8> cs8;
 
 

--- a/src/leansdr/sdr.h
+++ b/src/leansdr/sdr.h
@@ -14,6 +14,7 @@ namespace leansdr {
   typedef complex<u8> cu8;
   typedef complex<u16> cu16;
   typedef complex<s8> cs8;
+  typedef complex<s16> cs16;
 
 
   //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Simple patch to support int16_t and uint16_t files.

Tested with LimeSDR with a complex int16_t file from broadcast DVB-S signal from Astra satellite. 

There is an issue I'm not sure the best way to solve. Due to 16bit nature of the data, the graphs now don't show too much as they are scaled for a byte. There is the option of applying a scale in the cconverter class, but that will cause a truncation of the data (due to int operations) before stuffing it into a float32 - would be better to preserve all the bits, not just the MSB.

Thanks,

Matt