### PR TITLE
Fix macOS Sierra compilation errors.

### DIFF
--- a/src/apps/Makefile
+++ b/src/apps/Makefile
@@ -1,5 +1,6 @@
 APPS	= leandvb leansdrscan
 APPS	+= leansdrcat leantsgen leanchansim leandvbtx
+APPS	+= leandvb.embedded 
 
 all:	$(APPS)
 
@@ -9,6 +10,7 @@ clean:
 DEPS	= ../leansdr/*.h
 
 CXXFLAGS	= -O3 -I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable
+CXXFLAGS	+= -L/opt/X11/lib -lX11 -lpthread
 
 %:	%.cc $(DEPS)
 	g++ $(CXXFLAGS) -DGUI $< -lX11 -o $@  ||  \

--- a/src/apps/Makefile
+++ b/src/apps/Makefile
@@ -8,16 +8,15 @@ clean:
 
 DEPS	= ../leansdr/*.h
 
-CXXFLAGS = -O3 -I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable -Wno-tautological-compare
-CXXFLAGS += -L/opt/X11/lib -lX11 -lpthread
+CXXFLAGS	= -O3 -I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable
 
 %:	%.cc $(DEPS)
 	g++ $(CXXFLAGS) -DGUI $< -lX11 -o $@  ||  \
-	g++ $(CXXFLAGS)       $<      -o $@
+	g++ $(CXXFLAGS)       $<       -o $@
 
 EMBED_FLAGS=	-I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable  \
-		-Ofast -lm -mfpu=neon -funsafe-math-optimizations -fsingle-precision-constant -lm
+		-Ofast -mfpu=neon -funsafe-math-optimizations -fsingle-precision-constant
 
 leandvb.embedded:	leandvb.cc $(DEPS)
-	clang $(CXXFLAGS) $(EMBED_FLAGS) $< -static -o $@  ||  \
-	clang $(CXXFLAGS) $(EMBED_FLAGS) $<         -o $@
+	g++ $(CXXFLAGS) $(EMBED_FLAGS) $< -static -o $@  ||  \
+	g++ $(CXXFLAGS) $(EMBED_FLAGS) $<         -o $@

--- a/src/apps/Makefile
+++ b/src/apps/Makefile
@@ -8,15 +8,16 @@ clean:
 
 DEPS	= ../leansdr/*.h
 
-CXXFLAGS	= -O3 -I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable
+CXXFLAGS = -O3 -I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable -Wno-tautological-compare
+CXXFLAGS += -L/opt/X11/lib -lX11 -lpthread
 
 %:	%.cc $(DEPS)
 	g++ $(CXXFLAGS) -DGUI $< -lX11 -o $@  ||  \
-	g++ $(CXXFLAGS)       $<       -o $@
+	g++ $(CXXFLAGS)       $<      -o $@
 
 EMBED_FLAGS=	-I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable  \
-		-Ofast -mfpu=neon -funsafe-math-optimizations -fsingle-precision-constant
+		-Ofast -lm -mfpu=neon -funsafe-math-optimizations -fsingle-precision-constant -lm
 
 leandvb.embedded:	leandvb.cc $(DEPS)
-	g++ $(CXXFLAGS) $(EMBED_FLAGS) $< -static -o $@  ||  \
-	g++ $(CXXFLAGS) $(EMBED_FLAGS) $<         -o $@
+	clang $(CXXFLAGS) $(EMBED_FLAGS) $< -static -o $@  ||  \
+	clang $(CXXFLAGS) $(EMBED_FLAGS) $<         -o $@

--- a/src/apps/Makefile
+++ b/src/apps/Makefile
@@ -1,6 +1,5 @@
 APPS	= leandvb leansdrscan
 APPS	+= leansdrcat leantsgen leanchansim leandvbtx
-APPS	+= leandvb.embedded 
 
 all:	$(APPS)
 
@@ -9,8 +8,12 @@ clean:
 
 DEPS	= ../leansdr/*.h
 
-CXXFLAGS	= -O3 -I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable
-CXXFLAGS	+= -L/opt/X11/lib -lX11 -lpthread
+CXXFLAGS	= -O3 -I.. -Wall -Wno-sign-compare -Wno-array-bounds -Wno-unused-variable -Wno-tautological-compare
+
+OS := $(shell uname)
+ifeq ($(OS),Darwin)
+	CXXFLAGS	+= -L/opt/X11/lib -lX11 -lpthread
+endif
 
 %:	%.cc $(DEPS)
 	g++ $(CXXFLAGS) -DGUI $< -lX11 -o $@  ||  \

--- a/src/apps/leanchansim.cc
+++ b/src/apps/leanchansim.cc
@@ -21,11 +21,7 @@ struct drifter : runnable {
       t(0) {
     memset(drifts, 0, sizeof(drifts));
     for ( int i=0; i<65536; ++i )
-#ifdef __APPLE__
-      __sincosf(2*M_PI*i/65536, &lut_trig[i].im, &lut_trig[i].re);
-#else
       sincosf(2*M_PI*i/65536, &lut_trig[i].im, &lut_trig[i].re);
-#endif
   }
   
   static const int NCOMPONENTS = 3;

--- a/src/apps/leanchansim.cc
+++ b/src/apps/leanchansim.cc
@@ -21,7 +21,11 @@ struct drifter : runnable {
       t(0) {
     memset(drifts, 0, sizeof(drifts));
     for ( int i=0; i<65536; ++i )
+#ifdef __APPLE__
+      __sincosf(2*M_PI*i/65536, &lut_trig[i].im, &lut_trig[i].re);
+#else
       sincosf(2*M_PI*i/65536, &lut_trig[i].im, &lut_trig[i].re);
+#endif
   }
   
   static const int NCOMPONENTS = 3;

--- a/src/apps/leanchansim.cc
+++ b/src/apps/leanchansim.cc
@@ -21,7 +21,11 @@ struct drifter : runnable {
       t(0) {
     memset(drifts, 0, sizeof(drifts));
     for ( int i=0; i<65536; ++i )
+#ifdef __APPLE__
+      __sincosf(2*M_PI*i/65536, &lut_trig[i].im, &lut_trig[i].re);
+#else 
       sincosf(2*M_PI*i/65536, &lut_trig[i].im, &lut_trig[i].re);
+#endif
   }
   
   static const int NCOMPONENTS = 3;


### PR DESCRIPTION
Fix the compilation problems with macOS. These changes shouldn't interfere with other OS.
- Fix X11 C Library Path. 
- Fix _sincosf_ function.
- Suppress _-Wtautological-compare_.

![screenshot 2017-07-22 18 53 46](https://user-images.githubusercontent.com/6627901/28495660-435510c8-6f2c-11e7-8eed-ec3cb48e67f8.png)